### PR TITLE
docs: use /project learn skill with manual fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,12 @@ oracle-skills install rrr recap trace feel fyi forward standup where-we-are proj
 # ────────────────────────────────────────────────────────────────
 # STEP 6: Learn from the Starter Kit
 # ────────────────────────────────────────────────────────────────
-# Clone starter kit to ψ/learn/ for reference
-ghq get -u https://github.com/Soul-Brews-Studio/opensource-nat-brain-oracle
-ln -sf "$(ghq root)/github.com/Soul-Brews-Studio/opensource-nat-brain-oracle" ψ/learn/oracle-starter-kit
+# Use the /project learn skill to clone starter kit for reference
+/project learn https://github.com/Soul-Brews-Studio/opensource-nat-brain-oracle
+
+# If /project learn or /learn skill not available, use manual:
+# ghq get -u https://github.com/Soul-Brews-Studio/opensource-nat-brain-oracle
+# ln -sf "$(ghq root)/github.com/Soul-Brews-Studio/opensource-nat-brain-oracle" ψ/learn/oracle-starter-kit
 
 # Study the structure:
 # - CLAUDE.md — How to write identity


### PR DESCRIPTION
## Summary
- STEP 6 now uses `/project learn` skill (cleaner UX)
- Added manual fallback with `ghq` if skill not available

## Before
```bash
ghq get -u https://github.com/...
ln -sf "$(ghq root)/..." ψ/learn/oracle-starter-kit
```

## After
```bash
/project learn https://github.com/Soul-Brews-Studio/opensource-nat-brain-oracle

# If skill not available, use manual:
# ghq get -u ...
# ln -sf ...
```